### PR TITLE
C2PA-592: Recognize fonts which contain C2PA tables

### DIFF
--- a/magic/Magdir/fonts
+++ b/magic/Magdir/fonts
@@ -279,8 +279,8 @@
 >4	ubeshort	<47		
 # skip bad examples with garbage table names like in a5.show HYPERC MAC
 # tag names consist of up to four characters padded with spaces at end like
-# BASE DSIG OS/2 Zapf acnt glyf cvt vmtx xref ...
->>12	regex/4l	\^[A-Za-z][A-Za-z][A-Za-z/][A-Za-z2\ ]	
+# BASE C2PA DSIG OS/2 Zapf acnt glyf cvt vmtx xref ...
+>>12	regex/4l	\^[A-Za-z][A-Za-z2][A-Za-z/][A-Za-z2\ ]	
 #>>>0	ubelong	x	\b, sfnt version %#x
 >>>0	ubelong	!0x4f54544f	TrueType
 !:mime	font/sfnt

--- a/magic/Magdir/fonts
+++ b/magic/Magdir/fonts
@@ -276,7 +276,7 @@
 # maximal 27 tables found like in Skia.ttf
 # 46 different table names mentioned on Apple specification
 # skip 1st sequence of DOS 2 backup with path separator (\~92 or /~47) misinterpreted as table number
->4	ubeshort	<47		
+>4	ubeshort	<48
 # skip bad examples with garbage table names like in a5.show HYPERC MAC
 # tag names consist of up to four characters padded with spaces at end like
 # BASE C2PA DSIG OS/2 Zapf acnt glyf cvt vmtx xref ...

--- a/magic/Magdir/fonts
+++ b/magic/Magdir/fonts
@@ -295,8 +295,8 @@
 !:ext	otf
 >>>0	ubelong	x		Font data
 # DSIG=44454947h table name implies a digitally signed font
-# search range = number of tables * 16 =< maximal number of tables * 16 = 27 * 16 = 432
->>>12	search/432	DSIG		\b, digitally signed
+# search range = number of tables * 16 =< maximal number of tables * 16 = 28 * 16 = 432
+>>>12	search/448	DSIG		\b, digitally signed
 >>>4	ubeshort	x		\b, %d tables
 # minimal 9 tables found like in NISC18030.ttf
 #>>>4	ubeshort	<10		TMIN


### PR DESCRIPTION
## Functional Change

Update the regex that matches four-charact SFNT table tags to permit ASCII '2' (0x32) in the second position, so that fonts with C2PA tables do not confuse us.

## Steps to verify

Check out this topic branch and, from the repo folder:

```
# Install the bare minimum (pretty sure?)
#
sudo apt -y install gcc g++ make autoconf libtool

# Invoke autoreconf to create the build script
#
autoreconf --install --force --verbose

# Execute the configure script that was created.
#
./configure

# Build the tool
#
make
```

The new tool will appear in the `src` folder: `src/file`. Compare its operation to the system's built-in tool (since yours is not installed, you will need to pass `-m` with the magic-file to use...):

```
# Verify . not in $PATH
#
kushc@KEYOP:/mnt/c/chriskushmonotype/file/src$ which file
/usr/bin/file

# Check a non-C2PA font - both tools agree:
#
kushc@KEYOP:/mnt/c/chriskushmonotype/file/src$ file /mnt/c/Windows/Fonts/webdings.ttf
/mnt/c/Windows/Fonts/webdings.ttf: TrueType Font data, digitally signed, 19 tables, 1st "DSIG"

kushc@KEYOP:/mnt/c/chriskushmonotype/file/src$ ./file -m ../magic/magic.mgc /mnt/c/Windows/Fonts/webdings.ttf
/mnt/c/Windows/Fonts/webdings.ttf: TrueType Font data, digitally signed, 19 tables, 1st "DSIG"

# Check a C2PA-bearing font - only the new tool recognizes it
#
kushc@KEYOP:/mnt/c/chriskushmonotype/file/src$ file /mnt/c/Temp/C2PA/fonts/webdings.c2pa.ttf
/mnt/c/Temp/C2PA/fonts/webdings.c2pa.ttf: data

kushc@KEYOP:/mnt/c/chriskushmonotype/file/src$ ./file -m ../magic/magic.mgc /mnt/c/Temp/C2PA/fonts/webdings.c2pa.ttf
/mnt/c/Temp/C2PA/fonts/webdings.c2pa.ttf: TrueType Font data, digitally signed, 20 tables, 1st "C2PA"
```


